### PR TITLE
Add refresh route for guilds data

### DIFF
--- a/api_routes.py
+++ b/api_routes.py
@@ -11,15 +11,18 @@ def api_settings():
 @app.route('/api/guilds')
 def api_guilds():
     db.create_session()
-    if time.time()-db.session['guilds']['last_refresh'] > db.session['settings']['refresh_cooldown']:
-        try:
-            guild_data = client.api.get_guilds()
-            db.set(['guilds'], {
-                'last_refresh': time.time(),
-                'data': guild_data
-            })
-        except urllib3.exceptions.ProtocolError:
-            guild_data = db.get(['guilds', 'data']) # it updates? not exactly sure what causes this
-    else:
-        guild_data = db.session['guilds']['data']
+    guild_data = db.session['guilds']['data']
+    return guild_data
+
+@app.route('/api/guilds/refresh')
+def api_guilds_refresh():
+    db.create_session()
+    try:
+        guild_data = client.api.get_guilds()
+        db.set(['guilds'], {
+            'last_refresh': time.time(),
+            'data': guild_data
+        })
+    except urllib3.exceptions.ProtocolError:
+        guild_data = db.get(['guilds', 'data']) # it updates? not exactly sure what causes this
     return guild_data

--- a/static/scripts/index_load.js
+++ b/static/scripts/index_load.js
@@ -1,7 +1,16 @@
-
 var guildIndex = {}
+
+function refreshGuilds() {
+    return request("/api/guilds/refresh")
+}
+
+function loadGuilds() {
+    return request("/api/guilds")
+}
+
 window.onload = function() {
-    request("/api/guilds")
+    refreshGuilds()
+        .then(() => loadGuilds())
         .then(guilds => {
             const guildParent = dquery(".guild-container")
             guilds.forEach(function(guild) {


### PR DESCRIPTION
Add a new route to refresh guilds data and modify existing route to return cached data.

* **api_routes.py**
  - Add a new route `/api/guilds/refresh` to refresh guilds data from the Discord API.
  - Modify the `/api/guilds` route to return the cached guilds data without refreshing.

* **static/scripts/index_load.js**
  - Add a function `refreshGuilds` to call the new `/api/guilds/refresh` route.
  - Modify the `window.onload` function to call the new `refreshGuilds` function and then load the guilds data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Shrey3satdeve/multicord/pull/1?shareId=9becd247-770f-4da8-b3a4-18464b0dafd4).